### PR TITLE
Webrat::Selenium support for Rails 3

### DIFF
--- a/lib/webrat/selenium/application_servers/rails.rb
+++ b/lib/webrat/selenium/application_servers/rails.rb
@@ -30,12 +30,24 @@ module Webrat
           prepare_pid_file("#{::Rails.root}/tmp/pids", "mongrel_selenium.pid")
         end
 
+        def rails3
+          ::Rails.version =~ /^3/
+        end
+
         def start_command
-          "mongrel_rails start -d --chdir='#{::Rails.root}' --port=#{Webrat.configuration.application_port} --environment=#{Webrat.configuration.application_environment} --pid #{pid_file} &"
+          if rails3
+            "cd #{::Rails.root} && rails server -d --port=#{Webrat.configuration.application_port} --environment=#{Webrat.configuration.application_environment} --pid #{pid_file}"
+          else
+            "mongrel_rails start -d --chdir='#{::Rails.root}' --port=#{Webrat.configuration.application_port} --environment=#{Webrat.configuration.application_environment} --pid #{pid_file} &"
+          end
         end
 
         def stop_command
-          "mongrel_rails stop -c #{::Rails.root} --pid #{pid_file}"
+          if rails3
+            "kill -HUP `cat #{pid_file}`"
+          else
+            "mongrel_rails stop -c #{::Rails.root} --pid #{pid_file}"
+          end
         end
 
       end


### PR DESCRIPTION
mongrel_rails doesn't work starting a Rails 3 app, so I have patched `selenium/application_servers/rails.rb` to issue a "rails start" command instead for Rails 3 apps only.

Let me know what you think!
