### PR TITLE
Fixing webratlinkwithin with Selenium's new css engine

### DIFF
--- a/lib/webrat/selenium/location_strategy_javascript/webratlinkwithin.js
+++ b/lib/webrat/selenium/location_strategy_javascript/webratlinkwithin.js
@@ -1,7 +1,7 @@
 var locatorParts = locator.split('|');
 var cssAncestor = locatorParts[0];
 var linkText = locatorParts[1];
-var matchingElements = cssQuery(cssAncestor, inDocument);
+var matchingElements = eval_css(cssAncestor, inDocument);
 var candidateLinks = matchingElements.collect(function(ancestor){
   var links = ancestor.getElementsByTagName('a');
   return $A(links).select(function(candidateLink) {


### PR DESCRIPTION
Hi,

I work at [Sauce Labs](http://saucelabs.com) and since we moved our service to the current Selenium 2 jar (Selenium 2.0a7), a lot of our customers started having problems with their tests. I found the cause of the problem, it's just that at certain point in history, Selenium decided to replace cssQuery with [Sizzle](http://sizzlejs.com/) (jquery's selector engine), which broke one of the custom webrat's locating strategies (webratlinkwithin).

To fix it, I'm just using Selenium's cssQuery wrapper (eval_css) instead of straight cssQuery. This works in both Selenium's old jar (1.0.1) and Selenium's new jar (2.0a7).

For more info on the change in Selenium that broke it:
http://code.google.com/p/selenium/source/detail?r=9590

I'd love to get this on the mainstream so that everyone willing to use Sauce Labs or just switch to the new jar for local tests (which brings support for Firefox 3.6 on Mac OSX) can do it.

Thanks!
Santi
