### PR TITLE
Patch for Rails 3 controller redirects

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,15 +1,11 @@
 = Webrat - Ruby Acceptance Testing for Web applications
 
-- http://gitrdoc.com/brynary/webrat
 - http://groups.google.com/group/webrat
-- http://webrat.lighthouseapp.com/
-- http://github.com/brynary/webrat
-- #webrat on Freenode
+- http://github.com/jbrien/webrat
 
 == Description
 
-Webrat lets you quickly write expressive and robust acceptance tests for a Ruby
-web application. 
+This is my version to correct the session issues with a Rails 3 application. Webrat lets you quickly write expressive and robust acceptance tests for a Ruby web application. 
 
 == Features
 
@@ -53,11 +49,11 @@ Otherwise the Nokogiri gem, which Webrat depends on, won't install properly.
 
 To install the latest release as a gem:
 
-  sudo gem install webrat
+  sudo gem install jbd-webrat
   
 To install the latest code as a plugin: (_Note:_ This may be less stable than using a released version)
 
-  script/plugin install git://github.com/brynary/webrat.git
+  script/plugin install git://github.com/jbrien/webrat.git
 
 In your test_helper.rb or env.rb (for Cucumber) add:
 
@@ -74,6 +70,7 @@ methods from Webrat::Session in your specs.
 
 == Authors
 
+- Updated by {John Brien Dilts}[mailto:iam@hybridindie.com]
 - Maintained by {Bryan Helmkamp}[mailto:bryan@brynary.com]
 - Original code written by {Seth Fitzsimmons}[mailto:seth@mojodna.net]
 - Initial development was sponsored by EastMedia[http://www.eastmedia.com]
@@ -81,5 +78,4 @@ methods from Webrat::Session in your specs.
 
 == License
 
-Copyright (c) 2007-2008 Bryan Helmkamp, Seth Fitzsimmons.
 See MIT-LICENSE.txt in this directory.

--- a/lib/webrat/core/session.rb
+++ b/lib/webrat/core/session.rb
@@ -284,10 +284,18 @@ For example:
     def response_location
       response_headers['Location']
     end
-
+    
     def current_host
-      URI.parse(current_url).host || @custom_headers["Host"] || "www.example.com"
+      URI.parse(current_url).host || @custom_headers["Host"] || default_current_host
     end
+    
+    def default_current_host
+      adapter.class == Webrat::RackAdapter ? "example.org" : "www.example.com"
+    end
+    
+    #def current_host
+    #  URI.parse(current_url).host || @custom_headers["Host"] || "www.example.com"
+    #end
 
     def response_location_host
       URI.parse(response_location).host || "www.example.com"

--- a/webrat.gemspec
+++ b/webrat.gemspec
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{webrat}
-  s.version = "0.7.2"
+  s.name = %q{jbd-webrat}
+  s.version = "0.7.2.rails3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Bryan Helmkamp"]
-  s.date = %q{2010-10-19}
-  s.description = %q{Webrat lets you quickly write expressive and robust acceptance tests
+  s.authors = ["John Brien Dilts", "Bryan Helmkamp"]
+  s.date = %q{2010-12-16}
+  s.description = %q{Rails 3 working version of Webrat. Webrat lets you quickly write expressive and robust acceptance tests
 for a Ruby web application. It supports simulating a browser inside
 a Ruby process to avoid the performance hit and browser dependency of
 Selenium or Watir, but the same API can also be used to drive real
 Selenium tests when necessary (eg. for testing AJAX interactions).
 Most Ruby web frameworks and testing frameworks are supported.}
-  s.email = %q{bryan@brynary.com}
+  s.email = %q{brien@pinstails.com}
   s.extra_rdoc_files = [
     "README.rdoc",
     "MIT-LICENSE.txt",


### PR DESCRIPTION
Now that Rails 3 is an actual Rack application the testing urls are not working with controller redirects (redirect_to some_path). These return a page with only "You are being redirected." as the content currently and on webrat/master. This corrects that issue and allows for the redirects to happen as would be expected.
