### PR TITLE
Test for correct Selenium client import

### DIFF
--- a/lib/webrat/selenium/selenium_session.rb
+++ b/lib/webrat/selenium/selenium_session.rb
@@ -4,9 +4,9 @@ require "webrat/selenium/application_server_factory"
 require "webrat/selenium/application_servers/base"
 
 begin
-  require "selenium"
+  require "selenium/client"
 rescue LoadError => e
-  e.message << " (You may need to install the selenium-rc gem)"
+  e.message << " (You may need to install the selenium-webdriver gem)"
   raise e
 end
 


### PR DESCRIPTION
The selenium-webdriver gem provides all of the same Selenium client APIs that selenium-client does, but it doesn't include a selenium.rb file to satisfy `require "selenium"`. Webrat a) shouldn't care which Selenium client lib you're using and b) shouldn't be forcing you to the old one
