### PR TITLE
fix the link in the readme doc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Webrat - Ruby Acceptance Testing for Web applications
 
-- http://gitrdoc.com/brynary/webrat
+- http://rdoc.info/github/brynary/webrat/master/frames
 - http://groups.google.com/group/webrat
 - http://webrat.lighthouseapp.com/
 - http://github.com/brynary/webrat


### PR DESCRIPTION
bryan-
this fixes the link in the readme file (I see you put the right link under the description at the top of the page)
-jason
