### PR TITLE
A better patch for Rails 3 controller redirects

### DIFF
--- a/lib/webrat/adapters/rack.rb
+++ b/lib/webrat/adapters/rack.rb
@@ -4,6 +4,7 @@ module Webrat
   class RackAdapter
     extend Forwardable
 
+    attr :session
     def_delegators :@session, :get, :post, :put, :delete
 
     def initialize(session) #:nodoc:

--- a/lib/webrat/core/session.rb
+++ b/lib/webrat/core/session.rb
@@ -286,11 +286,15 @@ For example:
     end
 
     def current_host
-      URI.parse(current_url).host || @custom_headers["Host"] || adapter.session.rack_mock_session.default_host
+      URI.parse(current_url).host || @custom_headers["Host"] || default_current_host
     end
 
     def response_location_host
-      URI.parse(response_location).host || adapter.session.rack_mock_session.default_host
+      URI.parse(response_location).host || default_current_host
+    end
+
+    def default_current_host
+      adapter.session.rack_mock_session.default_host
     end
 
     def reset

--- a/lib/webrat/core/session.rb
+++ b/lib/webrat/core/session.rb
@@ -286,11 +286,11 @@ For example:
     end
 
     def current_host
-      URI.parse(current_url).host || @custom_headers["Host"] || "www.example.com"
+      URI.parse(current_url).host || @custom_headers["Host"] || adapter.session.rack_mock_session.default_host
     end
 
     def response_location_host
-      URI.parse(response_location).host || "www.example.com"
+      URI.parse(response_location).host || adapter.session.rack_mock_session.default_host
     end
 
     def reset

--- a/spec/integration/rack/test/webrat_rack_test.rb
+++ b/spec/integration/rack/test/webrat_rack_test.rb
@@ -8,7 +8,7 @@ class WebratRackTest < Test::Unit::TestCase
   include Webrat::HaveTagMatcher
 
   def build_rack_mock_session
-    Rack::MockSession.new(app, "www.example.com")
+    Rack::MockSession.new(app, "example.net")
   end
 
   def test_visits_pages


### PR DESCRIPTION
Actually this is a patch for Rack applications redirects.

This patch changes current specs and shows where they fail.

I think it is not so hard coded as forcing mock session to comply with Rack::Test 'example.org' url.
