### PR TITLE
Equals signs in <input> values

### DIFF
--- a/lib/webrat/core/elements/form.rb
+++ b/lib/webrat/core/elements/form.rb
@@ -110,7 +110,7 @@ module Webrat
       when :rack, :sinatra
         Rack::Utils.parse_nested_query(query_string)
       else
-        query_string.split('&').map {|query| { query.split('=').first => query.split('=').last }}
+        query_string.split('&').map {|query| { query.split('=',2).first => query.split('=',2).last }}
       end
     end
 


### PR DESCRIPTION
This fixes a bug where webrat strips form values after an equals sign.

https://webrat.lighthouseapp.com/projects/10503/tickets/401-webrat-doesnt-handle-form-fields-with-an-equals-sign
