### PR TITLE
Added configuration option to pass startup switches to Selenium browsers

### DIFF
--- a/lib/webrat/core/configuration.rb
+++ b/lib/webrat/core/configuration.rb
@@ -68,6 +68,9 @@ module Webrat
     # Set the firefox profile for selenium to use
     attr_accessor :selenium_firefox_profile
 
+    # Set Browser-specific options for Selenium session
+    attr_accessor :selenium_browser_options
+
     # How many redirects to the same URL should be halted as an infinite redirect
     # loop? Defaults to 10
     attr_accessor :infinite_redirect_limit
@@ -87,6 +90,7 @@ module Webrat
       self.selenium_browser_key = '*firefox'
       self.selenium_browser_startup_timeout = 5
       self.selenium_verbose_output = false
+      self.selenium_browser_options = {}
 
       tmp_dir = Pathname.new(Dir.pwd).join("tmp")
       self.saved_pages_dir = tmp_dir.exist? ? tmp_dir : Dir.pwd

--- a/lib/webrat/selenium/selenium_session.rb
+++ b/lib/webrat/selenium/selenium_session.rb
@@ -227,7 +227,7 @@ EOS
       Webrat::Selenium::ApplicationServerFactory.app_server_instance.boot
 
       create_browser
-      $browser.start
+      $browser.start_new_browser_session(Webrat.configuration.selenium_browser_options)
 
       extend_selenium
       define_location_strategies


### PR DESCRIPTION
Requires a version of the Selenium binary that accepts commandLineFlags being passed when asking the selenium server to launch a browser. Version 2.0 of that binary has been packaged, which is a major version bump. Feel free to revert that to an older release of the Selenium binary if an older one supports it.
