### PR TITLE
allow http HEAD requests

### DIFF
--- a/lib/webrat/adapters/mechanize.rb
+++ b/lib/webrat/adapters/mechanize.rb
@@ -20,6 +20,10 @@ module Webrat #:nodoc:
       @response = mechanize.get(url, data)
     end
 
+    def head(url, data, headers_argument_not_used = nil)
+      @response = mechanize.head(url, data)
+    end
+
     def post(url, data, headers_argument_not_used = nil)
       post_data = data.inject({}) do |memo, param|
         case param

--- a/lib/webrat/core/session.rb
+++ b/lib/webrat/core/session.rb
@@ -67,7 +67,7 @@ For example:
 
     def_delegators :@adapter, :response, :response_code, :response_body, :response_headers,
       :response_body=, :response_code=,
-      :get, :post, :put, :delete
+      :get, :post, :put, :delete, :head
 
     def initialize(adapter = nil)
       @adapter         = adapter
@@ -127,7 +127,8 @@ For example:
       @http_method  = http_method
       @data         = data
 
-      if internal_redirect?
+      # Do not follow redirects for HEAD requests
+      if internal_redirect? and http_method != 'head'
         check_for_infinite_redirects
         request_page(response_location, :get, {})
       end


### PR DESCRIPTION
I was writing cucumber-nagios tests and wanted to test that a redirect was working as expected.

The cleaest way I could think of was to do a HEAD request on the resource and check the Location header but t do that I needed webrat to make HEAD requests and not automatically follow the redirect that is returned.  This seemed better than hacking in an option to not follow the redirect on any request type.

Cheers,
Andrew
