### PR TITLE
Support for specifying application protocol (http, https, etc.) when creating selenium client

### DIFF
--- a/lib/webrat/core/configuration.rb
+++ b/lib/webrat/core/configuration.rb
@@ -52,6 +52,9 @@ module Webrat
 
     # Which server the application is running on for selenium testing? Defaults to localhost
     attr_accessor :application_address
+    
+    # Which protocol the application is running under? Defaults to http
+    attr_accessor :application_protocol
 
     # Which server Selenium server is running on. Defaults to nil(server starts in webrat process and runs locally)
     attr_accessor :selenium_server_address
@@ -81,6 +84,7 @@ module Webrat
       self.application_environment = :test
       self.application_port = 3001
       self.application_address = 'localhost'
+      self.application_protocol = 'http'
       self.application_framework = :rails
       self.selenium_server_port = 4444
       self.infinite_redirect_limit = 10

--- a/lib/webrat/selenium/selenium_session.rb
+++ b/lib/webrat/selenium/selenium_session.rb
@@ -240,7 +240,7 @@ EOS
         Webrat.configuration.selenium_server_address || "localhost",
         Webrat.configuration.selenium_server_port,
         Webrat.configuration.selenium_browser_key,
-        "http://#{Webrat.configuration.application_address}:#{Webrat.configuration.application_port_for_selenium}"
+        "#{Webrat.configuration.application_protocol}://#{Webrat.configuration.application_address}:#{Webrat.configuration.application_port_for_selenium}"
       )
       $browser.set_speed(0) unless Webrat.configuration.selenium_server_address
 

--- a/spec/private/core/configuration_spec.rb
+++ b/spec/private/core/configuration_spec.rb
@@ -62,6 +62,10 @@ describe Webrat::Configuration do
       @config.application_address.should == 'localhost'
     end
 
+    it 'should default application protocol to http' do
+      @config.application_protocol.should == 'http'
+    end
+
     it 'should default selenium server address to nil' do
       @config.selenium_server_address.should be_nil
     end


### PR DESCRIPTION
In my environment, I am required to run cucumber tests in an environment where apps can only be served via https, so I added the ability to pass an optional configuration attribute ("application_protocol") to webrat.

This might not be useful to most, but the attribute defaults to 'http' so shouldn't have any compatibilities issues. Also, others might have the same sort of restrictions that I have in my work environment.
