### PR TITLE
RSpec 2 support for rspec-rails

### DIFF
--- a/lib/webrat/integrations/rspec-rails.rb
+++ b/lib/webrat/integrations/rspec-rails.rb
@@ -6,6 +6,8 @@
 require "nokogiri"
 require "webrat/core/matchers"
 
-Spec::Runner.configure do |config|
+# If Rspec 2 is being used, avoid deprecation warning
+configure_method = defined?(RSpec) ? RSpec.method(:configure) : Spec::Runner.method(:configure)
+configure_method.call do |config|
   config.include(Webrat::Matchers, :type => [:controller, :helper, :view])
 end


### PR DESCRIPTION
We're using rspec 2 (2.6.0) with rails (3.1), and we currently get deprecation warnings coming from webrat.  The new syntax is RSpec.configure (instead of Spec::Runner.configure).

This patch provides support for the new syntax while retaining support for the old (depending on whether rspec 2 is installed or not).
