### PR TITLE
Avoid RSpec warning by providing a default example description

### DIFF
--- a/lib/webrat/core/matchers/have_selector.rb
+++ b/lib/webrat/core/matchers/have_selector.rb
@@ -4,6 +4,17 @@ module Webrat
   module Matchers
 
     class HaveSelector < HaveXpath #:nodoc:
+
+      # ==== Returns
+      # String:: The default description for the spec when it is not provided.
+      def description
+        "have selector #{@expected.inspect}" + if @options && @options.any?
+          " with #{@options.inspect}"
+        else
+          ''
+        end
+      end
+
       # ==== Returns
       # String:: The failure message.
       def failure_message


### PR DESCRIPTION
This is pretty necessary for specs like:

```
it { should have_selector 'form' }
```

With this patch we'll see the spec as `GET #new should have selector "form"`.
Currently it is very freaking scary:

```
GET #new should When you call a matcher in an example without a String, like this:
specify { object.should matcher } or this: it { should matcher }
RSpec expects the matcher to have a #description method.
You should either add a String to the example this matcher is being used in,
or give it a description method.
Then you won't have to suffer this lengthy warning again.
```
