### PR TITLE
Add default RSpec description for all matchers

### DIFF
--- a/lib/webrat/core/matchers/have_content.rb
+++ b/lib/webrat/core/matchers/have_content.rb
@@ -19,6 +19,12 @@ module Webrat
       end
 
       # ==== Returns
+      # String:: The default description for the spec when it is not provided.
+      def description
+        "contain #{@content.inspect}"
+      end
+
+      # ==== Returns
       # String:: The failure message.
       def failure_message
         "expected the following element's content to #{content_message}:\n#{squeeze_space(@element)}"

--- a/lib/webrat/core/matchers/have_selector.rb
+++ b/lib/webrat/core/matchers/have_selector.rb
@@ -6,16 +6,6 @@ module Webrat
     class HaveSelector < HaveXpath #:nodoc:
 
       # ==== Returns
-      # String:: The default description for the spec when it is not provided.
-      def description
-        "have selector #{@expected.inspect}" + if @options && @options.any?
-          " with #{@options.inspect}"
-        else
-          ''
-        end
-      end
-
-      # ==== Returns
       # String:: The failure message.
       def failure_message
         "expected following output to contain a #{tag_inspect} tag:\n#{@document}"

--- a/lib/webrat/core/matchers/have_xpath.rb
+++ b/lib/webrat/core/matchers/have_xpath.rb
@@ -68,6 +68,20 @@ module Webrat
         @expected
       end
 
+      def matcher_name
+        self.class.name.split('::').last.sub(/^Have/, '').downcase
+      end
+
+      # ==== Returns
+      # String:: The default description for the spec when it is not provided.
+      def description
+        "have #{matcher_name} #{@expected.inspect}" + if @options && @options.any?
+          " with #{@options.inspect}"
+        else
+          ''
+        end
+      end
+
       # ==== Returns
       # String:: The failure message.
       def failure_message


### PR DESCRIPTION
This is addition to #66 that provides the default description for all the matchers
