### PR TITLE
Searching for a field by name using a regex

### DIFF
--- a/lib/webrat/core/locators/field_named_locator.rb
+++ b/lib/webrat/core/locators/field_named_locator.rb
@@ -11,7 +11,11 @@ module Webrat
 
       def field_element
         field_elements.detect do |field_element|
-          field_element["name"] == @value.to_s
+          if @value.is_a?(Regexp)
+            field_element["name"] =~ @value
+          else
+            field_element["name"] == @value.to_s
+          end
         end
       end
 

--- a/spec/public/locators/field_named_spec.rb
+++ b/spec/public/locators/field_named_spec.rb
@@ -1,0 +1,15 @@
+require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+
+describe "field_named" do
+  it "should work when passed a regular expression for the name" do
+    with_html <<-HTML
+      <html>
+        <form>
+        <input type="text" name="user_1_input">
+        </form>
+      </html>
+    HTML
+    result = field_named(/user_\d_input/).element.attributes['name'].value
+    result.should == "user_1_input"
+  end
+end


### PR DESCRIPTION
Bug fix for when using a regular expression to fill in a field that is
not visible on the page, i.e. css attributes on the element are set to
"display:none;"
