### PR TITLE
Split to 2 strings for base64 encoded value

### DIFF
--- a/lib/webrat/core/elements/form.rb
+++ b/lib/webrat/core/elements/form.rb
@@ -110,7 +110,7 @@ module Webrat
       when :rack, :sinatra
         Rack::Utils.parse_nested_query(query_string)
       else
-        query_string.split('&').map {|query| { query.split('=').first => query.split('=').last }}
+        query_string.split('&').map {|query| { query.split('=', 2).first => query.split('=', 2).last }}
       end
     end
 


### PR DESCRIPTION
Hi,

Could you consider to merge this change? I think the query parameters should be devided to 2 strings because some of submitted values such as Rails authenticity_token is Base64-encoded and has '='.
