### PR TITLE
Fix override String#blank? on ActiveSupport.

### DIFF
--- a/lib/webrat/core_extensions/blank.rb
+++ b/lib/webrat/core_extensions/blank.rb
@@ -46,8 +46,10 @@ class Hash #:nodoc:
 end
 
 class String #:nodoc:
-  def blank?
-    self !~ /\S/
+  unless method_defined?(:blank?)
+    def blank?
+      self !~ /\S/
+    end
   end
 end
 


### PR DESCRIPTION
To confirm the presence or absence of the method defined in advance so as
not to overwrite.
